### PR TITLE
ref(account): decouple account logic from UI logic

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,10 +9,13 @@
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
   </head>
   <body>
+    <div align="center" id="dispError" style="color: red;"></div>
     <div id="viewMain" align="center" style="display: none; margin-top: 25px;">
       <button id="auth" class="btn btn-primary">Log in</button>
       </br>
       <button id="create" class="btn btn-primary">Create Account</button>
+      </br>
+      <button id="cancel" class="btn btn-primary">Cancel</button>
     </div>
     <div id="viewCreate" align="center" style="display: none; margin-top: 25px;">
       <input type="text" id="emailAddrCreate" placeholder="Email Address" />
@@ -22,7 +25,6 @@
       <input type="password" id="pw2Create" placeholder="Repeat Password" />
       </br>
       <button id="create2" class="btn btn-primary">Create Account</button>
-      <div align="center" id="createError" style="color: red;"></div>
     </div>
     <div id="viewAuth" align="center" style="display: none; margin-top: 25px;">
       <input type="text" id="emailAddrAuth" placeholder="Email Address" />
@@ -30,7 +32,6 @@
       <input type="password" id="pw1Auth" placeholder="Password" />
       </br>
       <button id="auth2" class="btn btn-primary">Log in</button>
-      <div align="center" id="authError" style="color: red;"></div>
     </div>
     <div id="viewConsent" align="center" style="display: none; margin-top: 25px;">
       </br>
@@ -38,6 +39,7 @@
       </br>
       </br>
       <button id="acceptConsent" class="btn btn-primary">Accept</button>
+      <button id="rejectConsent" class="btn btn-primary">Reject</button>
     </div>
     <div align="center" id="displaySeed"></div>
   </body>

--- a/src/index.js
+++ b/src/index.js
@@ -1,81 +1,76 @@
-import { expose } from 'postmsg-rpc'
 import Account from './account'
 
-const authenticateApp = async (origin, spaces) => {
-  console.log('ori', origin)
-  viewMain.style.display = 'block'
-
-  let account = new Account({ noPersist: true })
-  //let account = new Account()
-  const seed = await getSeed(account)
-  if (!account.isOriginAllowed(origin)) {
-    await getOriginConsent(account, origin)
-  }
-  return seed
-}
-
-const getOriginConsent = (account, origin) => {
+const getOriginConsent = (origin) => {
   viewConsent.style.display = 'block'
   consentText.innerHTML = `Allow ${origin} to access your 3Box account`
   return new Promise((resolve, reject) => {
     acceptConsent.addEventListener('click', () => {
       viewConsent.style.display = 'none'
-      account.allowOrigin(origin)
       resolve()
+    })
+    rejectConsent.addEventListener('click', () => {
+      viewConsent.style.display = 'none'
+      reject('Access denied')
     })
   })
 }
 
-const getSeed = account => {
-  if (account.seed) {
-    viewMain.style.display = 'none'
-    return Promise.resolve(account.seed)
-  }
+const getAuthInput = () => {
+  viewMain.style.display = 'block'
+
   return new Promise((resolve, reject) => {
     const createAccount = async () => {
       viewMain.style.display = 'none'
+      dispError.style.display = 'none'
       viewCreate.style.display = 'block'
 
       create2.addEventListener('click', async () => {
+        // TODO - validate input
         // TODO - check if pw1 = pw2
         const email = emailAddrCreate.value
         const pass = pw1Create.value
-        try {
-          const seed = await account.create(email, pass)
-          viewCreate.style.display = 'none'
-          resolve(seed)
-        } catch (e) {
-          createError.innerHTML = e.message
-        }
+        viewCreate.style.display = 'none'
+        resolve({
+          type: 'create',
+          email,
+          pass
+        })
       })
     }
     const authenticateAccount = () => {
       viewMain.style.display = 'none'
+      dispError.style.display = 'none'
       viewAuth.style.display = 'block'
 
       auth2.addEventListener('click', async () => {
+        // TODO - validate input
         const email = emailAddrAuth.value
         const pass = pw1Auth.value
-        try {
-          const seed = await account.auth(email, pass)
-          viewAuth.style.display = 'none'
-          resolve(seed)
-        } catch (e) {
-          authError.innerHTML = e.message
-        }
+        viewAuth.style.display = 'none'
+        resolve({
+          type: 'auth',
+          email,
+          pass
+        })
       })
     }
     auth.addEventListener('click', authenticateAccount)
     create.addEventListener('click', createAccount)
+    cancel.addEventListener('click', () => {
+      resolve({ type: 'cancel' })
+    })
   })
 }
 
-expose('auth', authenticateApp, {
-  postMessage: window.parent.postMessage.bind(window.parent),
-  getMessageData: e => {
-    if (e.data.sender === 'postmsg-rpc/client') {
-      e.data.args.unshift(e.origin)
-    }
-    return e.data
-  }
-})
+const displayError = message => {
+  dispError.style.display = 'block'
+  dispError.innerHTML = message
+}
+
+const opts = { noPersist: true }
+const actions = {
+  getAuthInput,
+  getOriginConsent,
+  displayError
+}
+const account = new Account(actions, opts)


### PR DESCRIPTION
This moves all account logic into the account module. Including the definition of the postmsg-rpc.