### PR TITLE
Check to see if iFrame has access to localStorage

### DIFF
--- a/iframe/check.js
+++ b/iframe/check.js
@@ -1,0 +1,15 @@
+export const checkIsCookieAccess = () => {
+  var test = "3ID-test";
+  try {
+    localStorage.setItem(test, test);
+    localStorage.removeItem(test);
+    return true;
+  } catch (e) {
+    alert(
+      "This site uses cookies to give you control of your data. Please enable cookies in your browser settings."
+    );
+    return false;
+  }
+};
+
+checkIsCookieAccess();


### PR DESCRIPTION
Here is the minimal viable fix to alert users the embedded iFrame is unable to access localStorage (a signal cookies are disabled for 3rd-party sites).

The popup message is the one supplied by Sena.

Still working on the best way to pass a custom message from the 3box.js configuration/setup so developers can customize the alert message. 